### PR TITLE
Fix for .ts files in python plugins

### DIFF
--- a/python.cmake
+++ b/python.cmake
@@ -4,12 +4,23 @@ macro(do_python_project)
 	find_package(Qt5LinguistTools)
 
 	if(${create_translations})
+		file(GLOB_RECURSE objects LIST_DIRECTORIES true ${CMAKE_SOURCE_DIR}/src/*)
+
+		set(dirs "")
+		foreach(o ${objects})
+			if(IS_DIRECTORY ${o})
+				list(APPEND dirs ${o})
+			endif()
+		endforeach()
+
 		pyqt5_create_translation(
 			qm_files
-			${CMAKE_SOURCE_DIR}/src ${additional_translations}
+			${CMAKE_SOURCE_DIR}/src ${dirs} ${additional_translations}
 			${CMAKE_SOURCE_DIR}/src/${PROJECT_NAME}_en.ts
 		)
 	endif()
+
+	add_custom_target(translations ALL DEPENDS ${qm_files})
 
 	file(GLOB_RECURSE source_files CONFIGURE_DEPENDS *.py)
 


### PR DESCRIPTION
`.ts` files were not generated for python plugins because of a missing dependency on the `.qm` files. It also wasn't processing subdirectories.