### PR TITLE
Add new project type for python module.

### DIFF
--- a/project.cmake
+++ b/project.cmake
@@ -107,10 +107,11 @@ elseif(${project_type} STREQUAL "tests")
 	include(${CMAKE_CURRENT_LIST_DIR}/tests.cmake)
 elseif(${project_type} STREQUAL "python_plugin")
 	include(${CMAKE_CURRENT_LIST_DIR}/python_plugin.cmake)
+elseif(${project_type} STREQUAL "python_module_plugin")
+	include(${CMAKE_CURRENT_LIST_DIR}/python_module_plugin.cmake)
 else()
 	message(FATAL_ERROR "unknown project type '${project_type}'")
 endif()
 
 
 do_project()
-

--- a/python.cmake
+++ b/python.cmake
@@ -4,7 +4,14 @@ macro(do_python_project)
 	find_package(Qt5LinguistTools)
 
 	if(${create_translations})
-		file(GLOB_RECURSE objects LIST_DIRECTORIES true ${CMAKE_SOURCE_DIR}/src/*)
+
+		if(EXISTS "${CMAKE_SOURCE_DIR}/__init__.py")
+			set(src_dir ${CMAKE_SOURCE_DIR})
+		else()
+			set(src_dir ${CMAKE_SOURCE_DIR}/src)
+		endif()
+
+		file(GLOB_RECURSE objects LIST_DIRECTORIES true ${src_dir}/*)
 
 		set(dirs "")
 		foreach(o ${objects})
@@ -15,8 +22,8 @@ macro(do_python_project)
 
 		pyqt5_create_translation(
 			qm_files
-			${CMAKE_SOURCE_DIR}/src ${dirs} ${additional_translations}
-			${CMAKE_SOURCE_DIR}/src/${PROJECT_NAME}_en.ts
+			${src_dir} ${dirs} ${additional_translations}
+			${src_dir}/${PROJECT_NAME}_en.ts
 		)
 	endif()
 

--- a/python_module_plugin.cmake
+++ b/python_module_plugin.cmake
@@ -10,20 +10,6 @@ macro(do_project)
 	do_python_project()
 endmacro()
 
-
-# sets `var` to TRUE if the given directory should be installed
-#
-function(is_interesting_python_dir var dir)
-	file(GLOB_RECURSE dir_content "${dir}/*.py")
-
-	if("X${dir_content}" STREQUAL "X")
-		set(${var} FALSE PARENT_SCOPE)
-	else()
-		set(${var} TRUE PARENT_SCOPE)
-	endif()
-endfunction()
-
-
 macro(do_src)
 	# this copies all the .py files into ${install_dir}/${PROJECT_NAME}
 
@@ -67,7 +53,6 @@ macro(do_src)
 	endforeach()
 
 	file(GLOB_RECURSE src_files RELATIVE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/*.py)
-	message(${src_files})
 
 	# # directories that go in bin/plugins/${name}
 	install(

--- a/python_module_plugin.cmake
+++ b/python_module_plugin.cmake
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 3.16)
+include(${CMAKE_CURRENT_LIST_DIR}/python.cmake)
+
+if(NOT DEFINED install_dir)
+	set(install_dir bin/plugins)
+endif()
+
+
+macro(do_project)
+	do_python_project()
+endmacro()
+
+
+# sets `var` to TRUE if the given directory should be installed
+#
+function(is_interesting_python_dir var dir)
+	file(GLOB_RECURSE dir_content "${dir}/*.py")
+
+	if("X${dir_content}" STREQUAL "X")
+		set(${var} FALSE PARENT_SCOPE)
+	else()
+		set(${var} TRUE PARENT_SCOPE)
+	endif()
+endfunction()
+
+
+macro(do_src)
+	# this copies all the .py files into ${install_dir}/${PROJECT_NAME}
+
+	# resources in the src directory
+	file(GLOB_RECURSE resources ${CMAKE_SOURCE_DIR}/*.ui ${CMAKE_SOURCE_DIR}/*.qrc)
+
+	foreach(object ${resources})
+		get_filename_component(ext "${object}" LAST_EXT)
+
+		if("${ext}" STREQUAL ".ui")
+			# process .ui files and copy the resulting .py in data
+			get_filename_component(name "${object}" NAME_WLE)
+			get_filename_component(folder "${object}" DIRECTORY)
+			set(output "${folder}/${name}.py")
+
+			execute_process(
+				COMMAND ${PYTHON_ROOT}/PCbuild/amd64/python.exe
+					-I
+					-m PyQt5.uic.pyuic
+					-o "${output}"
+					"${object}"
+				WORKING_DIRECTORY ${PYTHON_ROOT})
+
+			list(APPEND src_files "${output}")
+		elseif("${ext}" STREQUAL ".qrc")
+			# process .qrc files and copy the resulting .py in data
+			get_filename_component(name "${object}" NAME_WLE)
+			get_filename_component(folder "${object}" DIRECTORY)
+			set(output "${folder}/${name}.py")
+
+			execute_process(
+				COMMAND ${PYTHON_ROOT}/PCbuild/amd64/python.exe
+					-I
+					-m PyQt5.pyrcc_main
+					-o "${output}"
+					"${object}"
+				WORKING_DIRECTORY ${PYTHON_ROOT})
+
+			list(APPEND src_files "${output}")
+		endif()
+	endforeach()
+
+	file(GLOB_RECURSE src_files RELATIVE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/*.py)
+	message(${src_files})
+
+	# # directories that go in bin/plugins/${name}
+	install(
+		DIRECTORY ${CMAKE_SOURCE_DIR}
+		DESTINATION ${install_dir}
+		FILES_MATCHING PATTERN "*.py"
+		PATTERN ".git*" EXCLUDE
+		PATTERN "vsbuild" EXCLUDE)
+endmacro()


### PR DESCRIPTION
Add a new `python_module_plugin` for Python module such as `basic_games`. How it works:

- First it globs resources (`.qrc`) and UI (`.ui`) files and transform them in Python files with equivalent names (`resources.qrc` -> `resources.py`).
- Then it install the directory directly, including all Python files and excluding `.git` and `vsbuild`.

Known issues:
- The `install` can include empty folder containing non-python files, but it's kind of hard to exclude them using `cmake`.

Closes #9