### PR TITLE
Improve Python module installation.

### DIFF
--- a/python_module_plugin.cmake
+++ b/python_module_plugin.cmake
@@ -2,19 +2,46 @@ cmake_minimum_required(VERSION 3.16)
 include(${CMAKE_CURRENT_LIST_DIR}/python.cmake)
 
 if(NOT DEFINED install_dir)
-	set(install_dir bin/plugins)
+	set(install_dir "bin/plugins/${CMAKE_PROJECT_NAME}")
 endif()
 
+if(NOT DEFINED res_dir)
+	set(res_dir res)
+endif()
+
+if(NOT DEFINED lib_dir)
+	set(lib_dir lib)
+endif()
 
 macro(do_project)
 	do_python_project()
+
+	# install requirements if there are any
+	if(EXISTS "${CMAKE_SOURCE_DIR}/plugin-requirements.txt")
+		add_custom_command(
+			OUTPUT "${CMAKE_SOURCE_DIR}/${lib_dir}/"
+			COMMAND ${PYTHON_ROOT}/PCbuild/amd64/python.exe
+				-I
+				-m pip
+				install --force --disable-pip-version-check
+				--target="${CMAKE_SOURCE_DIR}/${lib_dir}"
+				-r "${CMAKE_SOURCE_DIR}/plugin-requirements.txt"
+			WORKING_DIRECTORY ${PYTHON_ROOT})
+		add_custom_target(libs ALL DEPENDS "${CMAKE_SOURCE_DIR}/${lib_dir}")
+	endif()
 endmacro()
 
 macro(do_src)
 	# this copies all the .py files into ${install_dir}/${PROJECT_NAME}
 
+	if(EXISTS "${CMAKE_SOURCE_DIR}/__init__.py")
+		set(src_dir ${CMAKE_SOURCE_DIR})
+	else()
+		set(src_dir ${CMAKE_SOURCE_DIR}/src)
+	endif()
+
 	# resources in the src directory
-	file(GLOB_RECURSE resources ${CMAKE_SOURCE_DIR}/*.ui ${CMAKE_SOURCE_DIR}/*.qrc)
+	file(GLOB_RECURSE resources ${src_dir}/*.ui ${src_dir}/*.qrc)
 
 	foreach(object ${resources})
 		get_filename_component(ext "${object}" LAST_EXT)
@@ -54,11 +81,27 @@ macro(do_src)
 
 	file(GLOB_RECURSE src_files RELATIVE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/*.py)
 
-	# # directories that go in bin/plugins/${name}
+	# directories that go in bin/plugins/${name}
 	install(
-		DIRECTORY ${CMAKE_SOURCE_DIR}
+		DIRECTORY "${src_dir}/"
 		DESTINATION ${install_dir}
 		FILES_MATCHING PATTERN "*.py"
 		PATTERN ".git*" EXCLUDE
 		PATTERN "vsbuild" EXCLUDE)
+
+	# copy the resource directory if it exists
+	if(EXISTS "${CMAKE_SOURCE_DIR}/${res_dir}")
+		install(
+			DIRECTORY "${CMAKE_SOURCE_DIR}/${res_dir}"
+			DESTINATION ${install_dir}
+		)
+	endif()
+
+	if(EXISTS "${CMAKE_SOURCE_DIR}/plugin-requirements.txt")
+		install(
+			DIRECTORY "${CMAKE_SOURCE_DIR}/${lib_dir}"
+			DESTINATION ${install_dir}
+		)
+	endif()
+
 endmacro()


### PR DESCRIPTION
A few improvements to the Python module stuff.

**Background:** When I initially wrote `basic_games`, I organized the repository so that users could directly download from GitHub, meaning the "root" of the repository is actually the "root" of the plugin. Looking back on this, it's not really a great idea, so for future plugins I'd rather use structure similar to the one described below.

**Features:**

- Allow Python module plugins to put source files in a `src` folder instead of directly at the root. This is actually much better than putting everything in the root folder because it avoids copying useless files (git files, etc.), and is also easier to use for external tools (`mypy` does not work well with root repository for instance).
- Allow Python module to provide resources in a separate folder. The default behavior is to copy the `res` folder at the root of the repository if it exists. The name of the folder can be changed by specifying the `res_dir` variable.
- Allow Python module to have dependencies. These dependencies are installed using `pip` in a `lib` folder that is then copied in the plugin folder (the name of the folder can be changed using the `lib_dir` variable). The list of dependencies is specified in the `plugin-requirements.txt` file.

An example of plugin that would use this is https://github.com/Holt59/modorganizer-installer_wizard/tree/cmake-common (`cmake_common` branch).

